### PR TITLE
Generates pkg-config .pc file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,5 @@ ltmain.sh
 *.lai
 *.la
 *.a
+
+*.pc

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -7,6 +7,17 @@ libpopennoshell_la_LDFLAGS = -shared
 libpopennoshell_la_CFLAGS = $(AM_CFLAGS)
 libpopennoshell_la_SOURCES = popen-noshell.c
 
+pkgconfigdir = $(libdir)/pkgconfig
+nodist_pkgconfig_DATA = libpopennoshell.pc
+
+libpopennoshell.pc: libpopennoshell.pc.in
+	sed -e 's![@]prefix[@]!$(prefix)!g' \
+		-e 's![@]exec_prefix[@]!$(exec_prefix)!g' \
+		-e 's![@]includedir[@]!$(includedir)!g' \
+		-e 's![@]libdir[@]!$(libdir)!g' \
+		-e 's![@]PACKAGE_VERSION[@]!$(PACKAGE_VERSION)!g' \
+		libpopennoshell.pc.in > $@
+
 noinst_PROGRAMS = test
 test_SOURCES = test.c
 test_LDADD = libpopennoshell.la

--- a/src/libpopennoshell.pc.in
+++ b/src/libpopennoshell.pc.in
@@ -1,0 +1,10 @@
+prefix=@exec_prefix@
+includedir=@includedir@
+libdir=@libdir@
+
+Name: popen-noshell
+Description: A version of popen that doesn't spawn processes using /bin/sh
+URL: https://github.com/falsovsky/popen-noshell
+Version: @PACKAGE_VERSION@
+Cflags: -I${includedir}
+Libs: -L${libdir} -lpopennoshell


### PR DESCRIPTION
Generates a neat .pc file to help out with linking with the library

```
 $ gcc src/test.c `pkg-config --libs libpopennoshell` -o test

 $ pkg-config --libs libpopennoshell
 -lpopennoshell
```
